### PR TITLE
Improve UI layout with separate badge rows and macOS-style dock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -1027,6 +1028,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1488,6 +1495,37 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -790,6 +790,7 @@ export default function Home() {
                   <HomeContent
                     onNavigateToClassroom={() => handleNavigate('classroom')}
                     onAssistantMessage={handleAssistantMessage}
+                    onStudentClick={handleOpenStudentProfile}
                   />
                 ) : activeTab === 'roundup' ? (
                   <RoundupContent onPrepForMeeting={() => handleNavigate('classroom')} />

--- a/src/components/assistant-panel.tsx
+++ b/src/components/assistant-panel.tsx
@@ -104,6 +104,42 @@ const generateMessageId = () => {
   return `msg-${Date.now()}-${messageIdCounter}`
 }
 
+// Helper function to get badge color
+const getBadgeColor = (badge: string) => {
+  const lowerBadge = badge.toLowerCase()
+
+  // Performance grades
+  if (lowerBadge.includes('excellent') || lowerBadge.includes('top performer')) {
+    return 'bg-green-100 text-green-800'
+  }
+  if (lowerBadge.includes('above average')) {
+    return 'bg-blue-100 text-blue-800'
+  }
+  if (lowerBadge.includes('average') || lowerBadge.includes('steady')) {
+    return 'bg-stone-100 text-stone-800'
+  }
+  if (lowerBadge.includes('below average') || lowerBadge.includes('needs support')) {
+    return 'bg-red-100 text-red-800'
+  }
+
+  // Behavioral/progress tags
+  if (lowerBadge.includes('improved') || lowerBadge.includes('improving')) {
+    return 'bg-emerald-100 text-emerald-800'
+  }
+  if (lowerBadge.includes('consistent') || lowerBadge.includes('hardworking')) {
+    return 'bg-indigo-100 text-indigo-800'
+  }
+  if (lowerBadge.includes('creative')) {
+    return 'bg-purple-100 text-purple-800'
+  }
+  if (lowerBadge.includes('engaged') || lowerBadge.includes('potential')) {
+    return 'bg-cyan-100 text-cyan-800'
+  }
+
+  // Default
+  return 'bg-muted text-muted-foreground'
+}
+
 function PTMResponseContent({ onStudentClick }: { onStudentClick?: (studentName: string) => void }) {
   const [currentPage, setCurrentPage] = useState(0)
 
@@ -190,21 +226,21 @@ function PTMResponseContent({ onStudentClick }: { onStudentClick?: (studentName:
         )}
         onClick={() => onStudentClick?.('Alice Wong')}
       >
-        <div className="flex items-start gap-3">
+        <div className="flex items-center gap-3">
           <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-sm font-medium ${getAvatarColor('Alice Wong')}`}>
             {getInitials('Alice Wong')}
           </div>
           <div className="flex flex-1 flex-col gap-1.5">
             <span className="font-semibold">Alice Wong</span>
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
-                Excellent
-              </span>
-              <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
-                Consistent and hardworking
-              </span>
-            </div>
           </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
+            Excellent
+          </span>
+          <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
+            Hardworking
+          </span>
         </div>
         <p className="text-sm text-muted-foreground">
           Alice recently scored an A in her latest assessment, a significant improvement from her consistent B grades. This positive trend demonstrates her dedication and hard work, making it a meaningful achievement to celebrate with her parents.
@@ -219,21 +255,21 @@ function PTMResponseContent({ onStudentClick }: { onStudentClick?: (studentName:
         )}
         onClick={() => onStudentClick?.('Reza Halim')}
       >
-        <div className="flex items-start gap-3">
+        <div className="flex items-center gap-3">
           <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-sm font-medium ${getAvatarColor('Reza Halim')}`}>
             {getInitials('Reza Halim')}
           </div>
           <div className="flex flex-1 flex-col gap-1.5">
             <span className="font-semibold">Reza Halim</span>
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
-                Above average
-              </span>
-              <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
-                Improved behavior
-              </span>
-            </div>
           </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
+            Above average
+          </span>
+          <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
+            Improved behavior
+          </span>
         </div>
         <p className="text-sm text-muted-foreground">
           Reza has shown remarkable growth and improvement since his last discipline case. The Case Management team&apos;s observations reveal a clear positive trajectory in both his behavior and academic engagement, a story worth celebrating with his parents.
@@ -252,23 +288,23 @@ function PTMResponseContent({ onStudentClick }: { onStudentClick?: (studentName:
               )}
               onClick={() => onStudentClick?.(student.name)}
             >
-              <div className="flex items-start gap-3">
+              <div className="flex items-center gap-3">
                 <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-sm font-medium ${getAvatarColor(student.name)}`}>
                   {getInitials(student.name)}
                 </div>
                 <div className="flex flex-1 flex-col gap-1.5">
                   <span className="font-semibold">{student.name}</span>
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
-                      {student.grade}
-                    </span>
-                    {student.tags.map((tag) => (
-                      <span key={tag} className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
                 </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-1.5">
+                <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
+                  {student.grade}
+                </span>
+                {student.tags.map((tag) => (
+                  <span key={tag} className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium">
+                    {tag}
+                  </span>
+                ))}
               </div>
               <p className="text-sm text-muted-foreground">
                 {student.description}
@@ -443,7 +479,7 @@ function AssistantBody({ onStudentClick, incomingMessage, onMessageProcessed }: 
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4">
-      <div className="flex flex-1 flex-col gap-3 overflow-y-auto rounded-lg bg-muted/20">
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:opacity-0 hover:[&::-webkit-scrollbar-thumb]:opacity-100 [&::-webkit-scrollbar-thumb]:transition-opacity">
           {messages.map((message) => (
             <div
               key={message.id}
@@ -492,24 +528,26 @@ function AssistantBody({ onStudentClick, incomingMessage, onMessageProcessed }: 
         </div>
 
       <div className="flex flex-col gap-2">
-        {/* Shortcut hints */}
-        <div className="flex items-center gap-2">
-          {promptShortcuts.map((shortcut) => (
-            <button
-              key={shortcut.command}
-              type="button"
-              onClick={() => {
-                setInput(shortcut.command)
-                setShowShortcuts(true)
-                setSelectedShortcutIndex(promptShortcuts.indexOf(shortcut))
-              }}
-              className="flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
-            >
-              <span className="text-muted-foreground">/</span>
-              <span>{shortcut.label}</span>
-            </button>
-          ))}
-        </div>
+        {/* Shortcut hints - only show when no messages */}
+        {messages.length === 0 && (
+          <div className="flex items-center gap-2">
+            {promptShortcuts.map((shortcut) => (
+              <button
+                key={shortcut.command}
+                type="button"
+                onClick={() => {
+                  setInput(shortcut.command)
+                  setShowShortcuts(true)
+                  setSelectedShortcutIndex(promptShortcuts.indexOf(shortcut))
+                }}
+                className="flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
+              >
+                <span className="text-muted-foreground">/</span>
+                <span>{shortcut.label}</span>
+              </button>
+            ))}
+          </div>
+        )}
 
         <div className="relative">
           {showShortcuts && filteredShortcuts.length > 0 && (

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -7,6 +7,7 @@ import {
   BookOpenIcon,
   MessageSquareIcon,
   ArrowRightIcon,
+  MoreHorizontalIcon,
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -17,6 +18,7 @@ const actionButtons = [
   { key: 'analyse', label: 'Analyse', icon: SparklesIcon },
   { key: 'learn', label: 'Learn', icon: BookOpenIcon },
   { key: 'communicate', label: 'Communicate', icon: MessageSquareIcon },
+  { key: 'more', label: 'More', icon: MoreHorizontalIcon },
 ]
 
 // Mock data for teacher widgets
@@ -53,9 +55,10 @@ const studentAlertsData = [
 interface HomeContentProps {
   onNavigateToClassroom?: () => void
   onAssistantMessage?: (message: string) => void
+  onStudentClick?: (studentName: string) => void
 }
 
-export function HomeContent({ onNavigateToClassroom, onAssistantMessage }: HomeContentProps = {}) {
+export function HomeContent({ onNavigateToClassroom, onAssistantMessage, onStudentClick }: HomeContentProps = {}) {
   const [assistantInput, setAssistantInput] = useState('')
 
   const handleAssistantSubmit = (e: React.FormEvent) => {
@@ -104,20 +107,24 @@ export function HomeContent({ onNavigateToClassroom, onAssistantMessage }: HomeC
         </div>
       </form>
 
-      {/* Quick Actions */}
-      <div className="grid grid-cols-2 gap-2 sm:gap-3 md:grid-cols-4">
-        {actionButtons.map((action) => {
-          const Icon = action.icon
-          return (
-            <button
-              key={action.key}
-              className="group flex h-24 flex-col items-center justify-center gap-2 rounded-lg border border-stone-200 bg-white shadow-sm transition-all hover:shadow-md sm:h-28 sm:gap-3"
-            >
-              <Icon className="size-4 text-stone-600 transition-colors group-hover:text-stone-900 sm:size-5" />
-              <span className="text-xs font-medium text-stone-900 sm:text-sm">{action.label}</span>
-            </button>
-          )
-        })}
+      {/* Quick Actions - macOS Dock Style */}
+      <div className="flex justify-center">
+        <div className="inline-flex items-end gap-2 rounded-2xl border border-stone-200/60 bg-white/80 px-3 py-2 shadow-lg backdrop-blur-sm sm:gap-3 sm:px-4 sm:py-3">
+          {actionButtons.map((action) => {
+            const Icon = action.icon
+            return (
+              <button
+                key={action.key}
+                className="group relative flex flex-col items-center justify-end gap-1 transition-all duration-200 ease-out hover:scale-150 hover:-translate-y-3 sm:gap-1.5"
+              >
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white border border-stone-200 shadow-sm transition-all group-hover:shadow-md sm:h-14 sm:w-14">
+                  <Icon className="size-5 text-stone-600 sm:size-6" />
+                </div>
+                <span className="absolute -bottom-6 whitespace-nowrap rounded-md bg-stone-900 px-2 py-1 text-xs font-medium text-white opacity-0 transition-opacity group-hover:opacity-100">{action.label}</span>
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       {/* Teacher Widgets Section */}
@@ -222,6 +229,7 @@ export function HomeContent({ onNavigateToClassroom, onAssistantMessage }: HomeC
             {studentAlertsData.map((alert) => (
               <button
                 key={alert.id}
+                onClick={() => onStudentClick?.(alert.student)}
                 className="flex w-full items-start gap-2.5 rounded-lg p-1.5 text-left transition-colors hover:bg-stone-50 sm:gap-3 sm:p-2"
               >
                 <div className="relative shrink-0">

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }


### PR DESCRIPTION
## Summary
- Move student badges to a dedicated row below student information for cleaner layout
- Implement macOS Dock-style quick action buttons with smooth hover effects, scaling, and tooltips
- Add scroll area component for improved assistant chat experience
- Hide assistant shortcuts when messages are present to reduce clutter
- Make student cards clickable from home alerts
- Enhance assistant panel with custom scrollbar styling

## Test plan
- [ ] Verify badge layout displays properly on student cards
- [ ] Test macOS Dock hover animations and tooltips
- [ ] Check assistant chat scrolling behavior
- [ ] Confirm student cards are clickable and navigate correctly
- [ ] Test responsive behavior on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)