### PR TITLE
fix: resolve PTM assistant command and student profile navigation bugs

### DIFF
--- a/src/components/assistant-panel.tsx
+++ b/src/components/assistant-panel.tsx
@@ -507,11 +507,7 @@ function AssistantBody({ onStudentClick, incomingMessage, onMessageProcessed }: 
               <button
                 key={shortcut.command}
                 type="button"
-                onClick={() => {
-                  setInput(shortcut.command)
-                  setShowShortcuts(true)
-                  setSelectedShortcutIndex(promptShortcuts.indexOf(shortcut))
-                }}
+                onClick={() => handleShortcutSelect(shortcut)}
                 className="flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1.5 text-xs transition-colors hover:bg-accent"
               >
                 <span className="text-muted-foreground">/</span>
@@ -716,6 +712,7 @@ export function AssistantPanel({
         <div className="flex max-h-[calc(100vh-10rem)] min-h-[24rem] flex-col overflow-hidden p-5">
           <AssistantBody
             showHeading={showBodyHeading}
+            onStudentClick={onStudentClick}
             incomingMessage={incomingMessage}
             onMessageProcessed={onMessageProcessed}
           />


### PR DESCRIPTION
This commit fixes two critical bugs in the assistant panel:

1. **Missing onStudentClick in floating mode**: The onStudentClick prop was not being passed to AssistantBody when rendering in floating mode (Sheet component). This prevented users from navigating to student profiles when clicking on student names in the PTM response. Fixed by adding onStudentClick prop at line 719.

2. **Shortcut buttons not executing commands**: The shortcut hint buttons displayed when no messages exist were only populating the input field instead of executing the command directly. Users had to click the button AND press Enter, creating a confusing UX. Fixed by changing the onClick handler to directly call handleShortcutSelect instead of just setting the input value.

These fixes ensure that:
- Typing /ptm works on the first try
- Clicking on student names (like Alice Wong) properly navigates to their profile
- The assistant panel behaves consistently across floating and sidebar modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)