### PR TITLE
Add Mark.ly branding to teaching page

### DIFF
--- a/src/components/forms-content.tsx
+++ b/src/components/forms-content.tsx
@@ -183,7 +183,7 @@ export function FormsContent() {
           <div className="flex items-center justify-between gap-4">
             <div className="flex items-center gap-3">
               <h1 className="text-2xl font-semibold tracking-tight">Template Library</h1>
-              <Badge variant="secondary" className="flex items-center gap-2 px-3 py-1.5">
+              <Badge variant="secondary" className="flex items-center gap-2 px-2 py-0.5">
                 <Image
                   src="/logos/ae-logo.png"
                   alt="AllEars"

--- a/src/components/teaching-content.tsx
+++ b/src/components/teaching-content.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { comingSoonToast } from '@/lib/coming-soon-toast'
+import Image from 'next/image'
 
 interface TeachingContentProps {
   defaultTab?: 'marking' | 'lesson-planning' | 'homework' | 'timetable'
@@ -144,7 +145,21 @@ export function TeachingContent({ defaultTab = 'marking', teacherId = 'teacher@e
         <div className="mx-auto w-full max-w-5xl">
           <div className="flex items-center justify-between mb-6">
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight">Teaching</h1>
+              <div className="flex items-center gap-3 mb-2">
+                <h1 className="text-2xl font-semibold tracking-tight">Teaching</h1>
+                <Badge variant="secondary" className="flex items-center gap-2 px-2 py-0.5">
+                  <div className="relative w-8 h-6 overflow-hidden shrink-0 flex items-center justify-center">
+                    <Image
+                      src="/logos/Markly.svg"
+                      alt="Mark.ly"
+                      width={48}
+                      height={48}
+                      className="size-12"
+                    />
+                  </div>
+                  <span className="text-xs font-medium">Powered by Mark.ly</span>
+                </Badge>
+              </div>
               <p className="text-sm text-muted-foreground">
                 Manage your teaching tasks and resources
               </p>


### PR DESCRIPTION
## Summary
- Add "Powered by Mark.ly" badge to the teaching page header, similar to the AllEars branding on forms page
- Update badge styling with reduced padding for a more compact appearance on both teaching and forms pages
- Use a 32x24px cropped logo container to display the Mark.ly logo at an optimal size

## Test plan
- [ ] Navigate to the teaching page and verify the "Powered by Mark.ly" badge appears next to the page title
- [ ] Verify the logo is properly cropped and displays correctly
- [ ] Check that the forms page "Powered by AllEars" badge maintains proper styling
- [ ] Run `npm run build` to ensure no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)