### PR TITLE
Implement /ptm trigger with expandable full prompt display

### DIFF
--- a/src/contexts/assistant-context.tsx
+++ b/src/contexts/assistant-context.tsx
@@ -20,6 +20,8 @@ export type Message = {
   content: string | React.ReactNode
   timestamp: Date
   isThinking?: boolean
+  command?: string // For slash commands like /ptm
+  fullPrompt?: string // The expanded prompt text
 }
 
 // Stored message type - only text content, no React nodes
@@ -30,6 +32,8 @@ type StoredMessage = {
   timestamp: string
   isThinking?: boolean
   isPTMResponse?: boolean // Flag to show placeholder for PTM responses
+  command?: string // Store slash command
+  fullPrompt?: string // Store full prompt text
 }
 
 // Assistant state
@@ -91,6 +95,8 @@ function loadFromStorage(): Partial<AssistantState> | null {
           content: '(PTM response - not persisted)',
           timestamp: new Date(msg.timestamp),
           isThinking: msg.isThinking,
+          command: msg.command,
+          fullPrompt: msg.fullPrompt,
         }
       }
 
@@ -100,6 +106,8 @@ function loadFromStorage(): Partial<AssistantState> | null {
         content: msg.content,
         timestamp: new Date(msg.timestamp),
         isThinking: msg.isThinking,
+        command: msg.command,
+        fullPrompt: msg.fullPrompt,
       }
     })
 
@@ -136,6 +144,8 @@ function saveToStorage(state: AssistantState): void {
             timestamp: msg.timestamp.toISOString(),
             isThinking: msg.isThinking,
             isPTMResponse: true,
+            command: msg.command,
+            fullPrompt: msg.fullPrompt,
           }
         }
 
@@ -146,6 +156,8 @@ function saveToStorage(state: AssistantState): void {
           timestamp: msg.timestamp.toISOString(),
           isThinking: msg.isThinking,
           isPTMResponse: false,
+          command: msg.command,
+          fullPrompt: msg.fullPrompt,
         }
       })
 


### PR DESCRIPTION
## Summary

Implemented the `/ptm` trigger feature that displays slash commands with expandable full prompt text. Users can now type `/ptm` and see both the shorthand command and the full prompt with a toggle to hide/show the details.

Key improvements:
- Collapsible message display for slash commands
- Full prompt text stored and persisted across sessions
- Improved UI spacing and scrolling behavior
- Edge-to-edge scrollbar for better visual integration

## Changes

### Message Type Enhancement
- Added `command?: string` field to store slash commands (e.g., `/ptm`)
- Added `fullPrompt?: string` field to store expanded prompt text
- Updated context persistence to save/load these new fields

### New Component
- `CollapsibleUserMessage` component displays commands with toggle button
- Initially expanded to show full prompt
- "Hide full message" / "Show full message" toggle for collapsing/expanding
- Follows the reference UI design

### Layout & Spacing Fixes
- Reduced gap between content and input from 4 to 2 (gap-4 → gap-2)
- Removed horizontal padding from main container for edge scrollbar
- Added px-5 to content wrapper to maintain proper message spacing
- Fixed floating mode scrolling with proper height constraints

### Styling Improvements
- Scrollbar now appears at the edge of the container
- Content maintains proper padding alignment
- Header and input controls maintain consistent alignment

## Testing

- ✅ Production build passes without errors
- ✅ All TypeScript types validate correctly
- ✅ Scrolling works in both floating and sidebar modes
- ✅ Message persistence works across sessions
- ✅ Responsive layout maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)