### PR TITLE
Fix full-page assistant scrollbar positioning at page edge

### DIFF
--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -443,23 +443,21 @@ const TabContent = memo(function TabContent({
   // Use currentUrl for content rendering decisions
   // Only render content for the current URL
   if (isAssistantTabActive) {
-    return (
-      <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-6">
-        {assistantMode === 'sidebar' ? (
-          <AssistantPanel
-            mode="sidebar"
-            isOpen
-            onOpenChange={setIsAssistantOpen}
-            onModeChange={handleAssistantModeChange}
-            showBodyHeading={false}
-            showHeaderControls={false}
-            onStudentClick={handleOpenStudentProfile}
-            onStudentClickWithClass={handleOpenStudentFromClass}
-          />
-        ) : (
-          <AssistantBody showHeading={false} onStudentClick={handleOpenStudentProfile} onStudentClickWithClass={handleOpenStudentFromClass} />
-        )}
+    return assistantMode === 'sidebar' ? (
+      <div className="mx-auto flex w-full max-w-2xl flex-1 min-h-0 flex-col gap-6">
+        <AssistantPanel
+          mode="sidebar"
+          isOpen
+          onOpenChange={setIsAssistantOpen}
+          onModeChange={handleAssistantModeChange}
+          showBodyHeading={false}
+          showHeaderControls={false}
+          onStudentClick={handleOpenStudentProfile}
+          onStudentClickWithClass={handleOpenStudentFromClass}
+        />
       </div>
+    ) : (
+      <AssistantBody showHeading={false} onStudentClick={handleOpenStudentProfile} onStudentClickWithClass={handleOpenStudentFromClass} fullPageMode={true} />
     )
   }
 
@@ -2141,7 +2139,7 @@ export default function Home() {
 
       <SidebarInset className="overflow-x-clip">
         <div className="flex flex-1 min-h-0 flex-col">
-          <div className="sticky top-0 z-20 w-full max-w-full overflow-hidden rounded-t-[17px] bg-background">
+          <div className="sticky top-0 z-20 flex-shrink-0 w-full max-w-full overflow-hidden rounded-t-[17px] bg-background">
             <div className="w-full max-w-full">
               <div ref={tabContainerRef} className="grid grid-cols-[minmax(0,1fr)_auto] w-full max-w-full items-stretch" suppressHydrationWarning>
                 <div className="flex flex-nowrap items-center gap-2 overflow-x-auto overflow-y-hidden tab-scrollbar-hidden min-w-0 px-4 py-2 bg-stone-100" suppressHydrationWarning>


### PR DESCRIPTION
## Summary

Fixed the scrollbar positioning issue in the full-page assistant panel. The scrollbar now appears at the absolute right edge of the main content container, following the same pattern used in ConversationView and other pages in the application.

## Problem

The assistant panel scrollbar was appearing nested inside a centered content wrapper instead of at the page edge. This made the scrollbar feel disconnected from the page layout.

## Solution

Implemented the ConversationView layout pattern:
- Uses full-width ScrollArea with padding instead of max-width constraints
- Separates concerns: messages area (scrollable) and input area (fixed footer)
- Follows established application pattern for proper flex hierarchy

## Changes

### `src/components/assistant-panel.tsx`
- Added `fullPageMode?: boolean` prop to AssistantBodyProps
- Created `renderMessages()` and `renderInput()` helper functions
- Implemented conditional rendering:
  - **Full-page mode**: `flex h-full flex-col` with ScrollArea (flex-1 min-h-0) for messages + fixed footer
  - **Sidebar mode**: Original ScrollArea pattern with assistant-scroll-mask
- Full-page layout uses full width with `px-6 py-4` padding for breathing room

### `src/app/[[...slug]]/page.tsx`
- Added `flex-shrink-0` to sticky header for proper flex layout
- Conditional routing: AssistantPanel (sidebar) vs AssistantBody (full-page)
- Pass `fullPageMode={true}` when rendering AssistantBody

## Technical Details

The fix leverages proper flexbox height constraints:
- Parent: `flex h-full flex-col` - takes full height
- ScrollArea: `flex-1 min-h-0` - fills available space, allows shrinking below content size
- Fixed footer: `flex-shrink-0` - maintains fixed height, doesn't participate in flex growth
- Content padding: `px-6 py-4` - provides edge spacing while scrollbar stays at absolute right

## Test Plan

- [x] Verify scrollbar appears at right edge of page in full-page assistant mode
- [x] Confirm messages scroll properly with auto-scroll-to-bottom
- [x] Test sidebar mode still works with existing ScrollArea styling
- [x] Check input footer stays fixed at bottom while messages scroll
- [x] Verify layout works responsively at different viewport sizes

## Related Issues

Resolves the scrollbar positioning issue reported when switching assistant to full-page mode.

🤖 Generated with Claude Code